### PR TITLE
feat(uart): enable serial console

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A platform to experiment with yocto and and bitbake, targeting a raspberry pi.
 - [yocto for pi 3](https://raspinterest.wordpress.com/2016/11/30/yocto-project-on-raspberry-pi-3/)
 - [building a linux distro for pi 3](https://www.lysator.liu.se/inbyggda-hack/pi/)
 - [ready set yocto - unofficial guide](https://github.com/jynik/ready-set-yocto)
+- [Hacking RB PI 4 using UART](https://lancesimms.com/RaspberryPi/HackingRaspberryPi4WithYocto_Part1.html)
 
 ### Recipes
 

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -278,4 +278,14 @@ CONF_VERSION = "2"
 MACHINE = "raspberrypi3-64"
 ENABLE_UART = "1"
 RPI_USE_U_BOOT = "1"
-EXTRA_IMAGE_FEATURES += "ssh-server-dropbear"
+
+# add an ssh server
+EXTRA_IMAGE_FEATURES += "ssh-server-openssh"
+# see https://yocto.yoctoproject.narkive.com/Mh8uTsLB/meta-raspberrypi-enable-serial-communication-pi-3#post3
+INSTALL:append = " rpi-config"
+
+# see https://github.com/RPi-Distro/repo/issues/22#issuecomment-191271144
+RPI_EXTRA_CONFIG = ' \n \
+    force_turbo=1 \n \
+    gpu_freq=300 \n \
+    '

--- a/docs/serial-connection.md
+++ b/docs/serial-connection.md
@@ -1,0 +1,38 @@
+# Serial Connection
+
+To get uart working with the pi, you need to do the following:
+
+- enable uart
+- force turbo
+- append the rpi-config
+
+Both settings can be set in `local.conf`.
+
+```
+# local.con
+ENABLE_UART = "1"
+INSTALL:append = " rpi-config"
+RPI_EXTRA_CONFIG = ' \n \
+    force_turbo=1 \n \
+    '
+```
+
+The following pins are used for the serial connection (layout when the pins are
+on the top left corner):
+
+- `A2` is the black wire
+- `A3` is the white wire
+- `A4` is the green wire
+
+```
+  0 1 2 3 4 5
+A o o x x x o ...
+B o o o o o o ...
+```
+
+Connection to the pi:
+
+```sh
+sudo tio /dev/ttyUSB0
+```
+


### PR DESCRIPTION
It is somewhat working with `tio` but there is just some gibberish text. Changing the baud rate between `57600`, `72000` and the default `152000` did not help.